### PR TITLE
Clarify allow_redirects

### DIFF
--- a/docs/community/release-process.rst
+++ b/docs/community/release-process.rst
@@ -42,7 +42,7 @@ A hotfix release will only include bug fixes that were missed when the project
 released the previous version. If the previous version of Requests released
 ``v10.2.7`` the hotfix release would be versioned as ``v10.2.8``.
 
-Hotfixes will **not** include upgrades to vendored dependences after
+Hotfixes will **not** include upgrades to vendored dependencies after
 ``v2.6.2``
 
 Reasoning

--- a/requests/api.py
+++ b/requests/api.py
@@ -33,7 +33,7 @@ def request(method, url, **kwargs):
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
     :type timeout: float or tuple
-    :param allow_redirects: (optional) Boolean. Set to True if POST/PUT/DELETE redirect following is allowed.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
     :type allow_redirects: bool
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) whether the SSL cert will be verified. A CA_BUNDLE path can also be provided. Defaults to ``True``.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2116,7 +2116,7 @@ class TestPreparingURLs(object):
         )
     )
     def test_preparing_url(self, url, expected):
-        r = requests.Request(url=url)
+        r = requests.Request('GET', url=url)
         p = r.prepare()
         assert p.url == expected
 
@@ -2130,6 +2130,6 @@ class TestPreparingURLs(object):
         )
     )
     def test_preparing_bad_url(self, url):
-        r = requests.Request(url=url)
+        r = requests.Request('GET', url=url)
         with pytest.raises(requests.exceptions.InvalidURL):
             r.prepare()


### PR DESCRIPTION
Make API documentation consistent with clearer quickstart doc.